### PR TITLE
Removed API version validation.

### DIFF
--- a/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/util/SdkUtils.java
+++ b/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/util/SdkUtils.java
@@ -90,9 +90,8 @@ public class SdkUtils {
         // Get version
         final ApplianceDetailsDto applianceDetailsDto = applianceDetails.getVersion(params);
         // validate the API version
-        validateApiVersion(params.getApiVersion(), applianceDetailsDto.getCurrentVersion());
+        validateApiVersion(params.getApiVersion(), applianceDetailsDto.getMinimumVersion(), applianceDetailsDto.getCurrentVersion());
 
-        params.setApiVersion(applianceDetailsDto.getCurrentVersion());
         // Create LoginSessionDto;
         final LoginSessionDto loginSessionDto = loginSessionAdaptor.buildDto(params);
         // Get login session
@@ -110,23 +109,19 @@ public class SdkUtils {
         return params;
     }
 
-    private void validateApiVersion(final int actualVersion, final int expectedVersion) {
-
+    private void validateApiVersion(final int requestedVersion, final int applianceMinimumVersion, final int applianceCurrentVersion) {
         logger.info("########### Checking API Version Start ####################");
-        if (expectedVersion == actualVersion) { // e.g. v 120 == v 120
-            logger.info("API version : " + "You are trying to connect to appliance verion: " + actualVersion
-                    + " and it is matching with your expected version:" + expectedVersion);
-        } else if (actualVersion > expectedVersion) {
-            logger.error("API Version Mismatch :" + "actual Version is : " + actualVersion + "expected version is : "
-                    + expectedVersion);
-            throw new SDKApiVersionMismatchException(SDKErrorEnum.apiMismatchError, null, null, null, SdkConstants.APPLIANCE, null);
-        } else if (actualVersion < expectedVersion) {
-            logger.error("API Version Mismatch :" + "actual Version is : " + actualVersion + "expected version is : "
-                    + expectedVersion);
-            throw new SDKApiVersionMismatchException(SDKErrorEnum.apiMismatchError, null, null, null, SdkConstants.APPLIANCE, null);
+
+        if (requestedVersion >= applianceMinimumVersion && requestedVersion  <= applianceCurrentVersion) {
+            logger.info("API version : You are trying to connect to appliance verion: "
+                    + requestedVersion  + " and it is matching with the minimum and current version ("
+                    + applianceMinimumVersion + " to " + applianceCurrentVersion + ")");
+
+            logger.info("########### Checking API Version End ####################");
+            return;
         }
 
-        logger.info("########### Checking API Version End ####################");
+        throw new SDKApiVersionMismatchException(SDKErrorEnum.apiMismatchError, null, null, null, SdkConstants.APPLIANCE, null);
     }
 
     public String getConnectionTemplateUri(final RestParams params, final String connectionTemplateName) {

--- a/samples/src/main/java/com/hp/ov/sdk/constants/samples/SamplesConstants.java
+++ b/samples/src/main/java/com/hp/ov/sdk/constants/samples/SamplesConstants.java
@@ -25,16 +25,17 @@ public class SamplesConstants {
     public static final String SCMB_ALERTS_ROUTING_KEY = "scmb.alerts.#";
     public static final String MSMB_EXCHANGE_NAME = "msmb";
     public static final String MSMB_ALERTS_ROUTING_KEY = "msmb.#";
-    public static final String KEY_STORE_PASSWORD = "changeit";
-    public static final String TRUST_STORE_PASSWORD = "changeit";
     public static final String KEY_STORE_FILE = "src/main/resources/KeyStore";
     public static final String TRUST_STORE_FILE = "src/main/resources/TrustStore";
     public static final String KEY_STORE_TYPE = "jks";
     public static final String TRUST_STORE_TYPE = "jks";
-    public static final String HOSTNAME = "10.10.10.2"; // sample value, change
-                                                        // it during testing
+    public static final String DOMAIN = "LOCAL";
+
+    // MOST LIKELY TO CHANGE ACCORDING TO YOUR CONFIGURATION
+    public static final int VERSION = 120;
+    public static final String KEY_STORE_PASSWORD = "changeit";
+    public static final String TRUST_STORE_PASSWORD = "changeit";
+    public static final String HOSTNAME = "10.10.10.2";
     public static final String USERNAME = "administrator";
     public static final String PASSWORD = "admin";
-    public static final String DOMAIN = "LOCAL";
-    public static final int VERSION = 120;
 }


### PR DESCRIPTION
It is now possible to use API 1.2 on OneView 2.0
