### PR TITLE
Fix for #26: Deserialization error in getAllAttachmentPaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Refactoring:
   - ```InterconnectSettingsV2``` updated to ```InterconnectSettings```
 
 #### Bug fixes:
+- [#26](https://github.com/HewlettPackard/oneview-sdk-java/issues/26) Exception in `getAllAttachmentPaths` method
 
 ## v3.2.1
 This release sets back API 300 as default.

--- a/automated-tests/src/main/java/com/hp/ov/sdk/storage/StorageVolumeAttachmentResource.java
+++ b/automated-tests/src/main/java/com/hp/ov/sdk/storage/StorageVolumeAttachmentResource.java
@@ -86,11 +86,11 @@ public class StorageVolumeAttachmentResource extends BasicResource implements Re
     }
 
     public int getAllAttachmentPath(String id) {
-        return client.getAllAttachmentPaths(id).size();
+        return client.getAllAttachmentPaths(id).getMembers().size();
     }
 
     public String getVolumeAttachmentPath(String id) {
-        List<StorageVolumeAttachmentPath> paths = client.getAllAttachmentPaths(id);
+        List<StorageVolumeAttachmentPath> paths = client.getAllAttachmentPaths(id).getMembers();
         StorageVolumeAttachmentPath path = null;
         for (StorageVolumeAttachmentPath p : paths) {
             if (p.getUri().contains(id)) {

--- a/automated-tests/src/test/java/com/hp/ov/sdk/resources/storage/StorageVolumeAttachmentBDDTestC7000.java
+++ b/automated-tests/src/test/java/com/hp/ov/sdk/resources/storage/StorageVolumeAttachmentBDDTestC7000.java
@@ -22,12 +22,11 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(format = { "pretty", "html:target/cucumber" }, 
+@CucumberOptions(format = { "pretty", "html:target/cucumber" },
     glue = { "com.hp.ov.sdk.resources" },
     features = "classpath:cucumber/storage/storageVolumeAttachmentC7000.feature",
     monochrome = true,
-    tags = { "@create, @getAll, @get, @update, @repair, @remove",
-            "~@disabled" })
+    tags = "@create, @getAll, @get, @update, @repair, @remove")
 
 public class StorageVolumeAttachmentBDDTestC7000 {
 

--- a/automated-tests/src/test/resources/cucumber/storage/storageVolumeAttachmentC7000.feature
+++ b/automated-tests/src/test/resources/cucumber/storage/storageVolumeAttachmentC7000.feature
@@ -209,8 +209,7 @@ Feature: In order to manage Storage Volume Attachments
     When OneView gets Resource by Name
     Then I get an ID
 
-  #Disabled because of issue #305 in SDK
-  @getAll @disabled
+  @getAll
   Scenario: Get all Storage Volume Attachment Paths
     Given name "storage-volume-bdd-sva" for Resource
     When OneView gets Resource by Name

--- a/automated-tests/src/test/resources/cucumber/storage/storageVolumeAttachmentSynergy.feature
+++ b/automated-tests/src/test/resources/cucumber/storage/storageVolumeAttachmentSynergy.feature
@@ -253,8 +253,7 @@ Feature: In order to manage Storage Volume Attachments
     When OneView gets Resource by Name
     Then I get an ID
 
-  #Disabled because of issue #305 in SDK
-  @getAll @disabled
+  @getAll
   Scenario: Get all Storage Volume Attachment Paths
     Given name "storage-volume-bdd-sva" for Resource
     When OneView gets Resource by Name

--- a/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/rest/client/storage/StorageVolumeAttachmentClient.java
+++ b/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/rest/client/storage/StorageVolumeAttachmentClient.java
@@ -15,8 +15,6 @@
  */
 package com.hp.ov.sdk.rest.client.storage;
 
-import java.util.List;
-
 import com.hp.ov.sdk.dto.ResourceCollection;
 import com.hp.ov.sdk.dto.TaskResource;
 import com.hp.ov.sdk.dto.storage.ExtraStorageVolume;
@@ -58,10 +56,10 @@ public interface StorageVolumeAttachmentClient extends SearchableResource<Storag
      *
      * @param attachmentId storage volume attachment identifier as seen in HPE OneView.
      *
-     * @return {@link List} of {@link StorageVolumeAttachmentPath} containing the details.
+     * @return {@link ResourceCollection}&lt;{@link StorageVolumeAttachmentPath}&gt; containing the details.
      */
     @Endpoint(uri = "/{attachmentId}" + STORAGE_VOLUME_ATTACHMENT_PATH_URI)
-    List<StorageVolumeAttachmentPath> getAllAttachmentPaths(@PathParam("attachmentId") String attachmentId);
+    ResourceCollection<StorageVolumeAttachmentPath> getAllAttachmentPaths(@PathParam("attachmentId") String attachmentId);
 
     /**
      * Returns the extra storage volume details for all the available extra storage volumes

--- a/oneview-sdk-java-lib/src/test/java/com/hp/ov/sdk/rest/client/storage/StorageVolumeAttachmentClientTest.java
+++ b/oneview-sdk-java-lib/src/test/java/com/hp/ov/sdk/rest/client/storage/StorageVolumeAttachmentClientTest.java
@@ -100,7 +100,7 @@ public class StorageVolumeAttachmentClientTest {
         Request expectedRequest = new Request(HttpMethod.GET, expectedUri);
 
         then(baseClient).should().executeRequest(expectedRequest,
-                new TypeToken<List<StorageVolumeAttachmentPath>>() {}.getType());
+                new TypeToken<ResourceCollection<StorageVolumeAttachmentPath>>() {}.getType());
     }
 
     @Test

--- a/samples/src/main/java/com/hp/ov/sdk/rest/client/storage/StorageVolumeAttachmentClientSample.java
+++ b/samples/src/main/java/com/hp/ov/sdk/rest/client/storage/StorageVolumeAttachmentClientSample.java
@@ -15,8 +15,6 @@
  *******************************************************************************/
 package com.hp.ov.sdk.rest.client.storage;
 
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +69,7 @@ public class StorageVolumeAttachmentClientSample {
     }
 
     private void getAllStorageVolumeAttachmentPaths() {
-        List<StorageVolumeAttachmentPath> storageVolumeAttachmentPaths
+        ResourceCollection<StorageVolumeAttachmentPath> storageVolumeAttachmentPaths
                 = this.storageVolumeAttachmentClient.getAllAttachmentPaths(STORAGE_VOLUME_ATTACHMENT_ID);
 
         LOGGER.info("Storage volume attachment paths returned to client: {}",


### PR DESCRIPTION
<!--- Texts inside this are invisible and will not be displayed on the pull request -->
### Description
<!--- Describe what this change achieves -->
Fixes the following deserialization error in getAllAttachmentPaths:
`Exception in thread "main" com.hp.ov.sdk.exceptions.SDKInternalException: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 1 column 2 path $`.

Root cause:
Method was incorrectly returning a list instead of a collection.

### Issues Resolved
<!--- List any issues this PR will resolve. e.g.: Fixes #01 -->
Fixes #26 

---
#### Check List
- [x] New functionality includes testing
- [x] New functionality has been thoroughly documented in the examples
- ~~[ ] New functionality has been documented in the [`README.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/README.md) if applicable~~
- [x] New functionality has been documented in the [`CHANGELOG.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/CHANGELOG.md) if applicable
- ~~[ ] New functionality has been documented in the [`endpoints-support.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/endpoints-support.md) if applicable~~
