### PR TITLE
Fix for #28: Error "CRM_INCORRECT_VALUE_IN_READONLY_FIELD" when updating Logical Switch 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ This release adds support to OneView Rest API version 500 to the already existin
 
 #### Enhancements:
 Refactoring:
-  - ```EthernetInterconnectSettingsV2``` updated to ```EthernetInterconnectSettings```
-  - ```InterconnectSettingsV2``` updated to ```InterconnectSettings```
+  - `EthernetInterconnectSettingsV2` updated to `EthernetInterconnectSettings`
+  - `InterconnectSettingsV2` updated to `InterconnectSettings`
 
 #### Bug fixes:
+- [#28](https://github.com/HewlettPackard/oneview-sdk-java/issues/28) `CRM_INCORRECT_VALUE_IN_READONLY_FIELD` returned when updating Logical Switch
 
 ## v3.2.1
 This release sets back API 300 as default.
@@ -25,13 +26,13 @@ This release sets back API 300 as default.
 #### New Features:
 This release adds support to new endpoints to OneView Rest API version 300 to the already existing features:
   - Logical Interconnect
-    - _GET_ ```ethernetSettings```
+    - _GET_ `ethernetSettings`
   - Interconnect
-    - _GET_ ```ports```
-    - _GET_ ```ports/{portId:.+}```
+    - _GET_ `ports`
+    - _GET_ `ports/{portId:.+}`
   - Network Sets
-    - _GET_ ```withoutEthernet```
-    - _GET_ ```{id}/withoutEthernet```
+    - _GET_ `withoutEthernet`
+    - _GET_ `{id}/withoutEthernet`
 
 This release adds support to OneView Rest API version 500 to the already existing features:
   - Ethernet Network

--- a/automated-tests/src/test/java/com/hp/ov/sdk/resources/network/LogicalSwitchBDDTest.java
+++ b/automated-tests/src/test/java/com/hp/ov/sdk/resources/network/LogicalSwitchBDDTest.java
@@ -27,8 +27,7 @@ import cucumber.api.junit.Cucumber;
     glue = { "com.hp.ov.sdk.resources" },
     features = "classpath:cucumber/network/logicalSwitch.feature",
     monochrome = true,
-    tags = { "@create, @getAll, @get, @update, @refresh, @remove",
-            "~@disabled"})
+    tags = "@create, @getAll, @get, @update, @refresh, @remove")
 
 /*
  * C7000 only

--- a/automated-tests/src/test/resources/cucumber/network/logicalSwitch.feature
+++ b/automated-tests/src/test/resources/cucumber/network/logicalSwitch.feature
@@ -68,8 +68,7 @@ Feature: In order to manage Logical Switches
       And OneView gets Resource by ID
     Then I get a Resource Name
 
-  #Disabled because of issue #317 in SDK
-  @update @disabled
+  @update
   Scenario: Update a Logical Switch
     Given Resource values as follows:
       | name     | switch-bdd |

--- a/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/adaptors/DateAdapter.java
+++ b/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/adaptors/DateAdapter.java
@@ -37,7 +37,7 @@ public class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DateAdapter.class);
 
-    public static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+    public static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     @Override
     public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {


### PR DESCRIPTION
<!--- Texts inside this are invisible and will not be displayed on the pull request -->
### Description
<!--- Describe what this change achieves -->
It fixes the following error when updating Logical Switch:
`"CRM_INCORRECT_VALUE_IN_READONLY_FIELD", "The expected value for field modified is 2017-08-24T12:13:59.868Z but the actual value was 2017-08-24T09:13:59.868-03."`.

Date format changed to the same used by OV: `Format YYYY-MM-DDThh:mm:ss.sssZ`.

### Issues Resolved
<!--- List any issues this PR will resolve. e.g.: Fixes #01 -->
Fixes #28 

---
#### Check List
- [x] New functionality includes testing
- [x] New functionality has been thoroughly documented in the examples
- ~~[ ] New functionality has been documented in the [`README.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/README.md) if applicable~~
- [x] New functionality has been documented in the [`CHANGELOG.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/CHANGELOG.md) if applicable
- ~~[ ] New functionality has been documented in the [`endpoints-support.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/endpoints-support.md) if applicable~~
