### PR TITLE
Workaround for #17 - Get all alerts using filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Refactoring:
   - `InterconnectSettingsV2` updated to `InterconnectSettings`
 
 #### Bug fixes:
+- [#17](https://github.com/HewlettPackard/oneview-sdk-java/issues/17) Sample method created to guarantee all alerts will be returned from `get(@QueryParam URIQuery query)`
 - [#28](https://github.com/HewlettPackard/oneview-sdk-java/issues/28) `CRM_INCORRECT_VALUE_IN_READONLY_FIELD` returned when updating Logical Switch
 - [#26](https://github.com/HewlettPackard/oneview-sdk-java/issues/26) Exception in `getAllAttachmentPaths` method
 

--- a/samples/src/main/java/com/hp/ov/sdk/rest/client/activity/AlertClientSample.java
+++ b/samples/src/main/java/com/hp/ov/sdk/rest/client/activity/AlertClientSample.java
@@ -26,6 +26,9 @@ import com.hp.ov.sdk.dto.alerts.AlertResource;
 import com.hp.ov.sdk.dto.alerts.AlertUpdate;
 import com.hp.ov.sdk.dto.alerts.AlertUrgency;
 import com.hp.ov.sdk.rest.client.OneViewClient;
+import com.hp.ov.sdk.rest.http.core.BasicURIQuery;
+import com.hp.ov.sdk.rest.http.core.URIQuery;
+import com.hp.ov.sdk.rest.http.core.UrlParameter;
 
 public class AlertClientSample {
 
@@ -55,6 +58,16 @@ public class AlertClientSample {
         ResourceCollection<AlertResource> alertResources = this.client.getAll();
 
         LOGGER.info("Alerts returned to client (count): {}", alertResources.getCount());
+    }
+
+    private void getAllAlertsByState() {
+        BasicURIQuery basicUriQuery = new BasicURIQuery();
+        basicUriQuery.addParameter(URIQuery.FILTER, "alertState='Active'"); //Filters alerts by Active state
+        basicUriQuery.addParameter(UrlParameter.getCountParameter(this.client.getAll().getCount())); //It guarantees all alerts will be returned
+
+        ResourceCollection<AlertResource> alerts = this.client.get(basicUriQuery);
+
+        LOGGER.info("Active alerts returned to client: {}", alerts.toJsonString());
     }
 
     private void updateAlert() {
@@ -93,6 +106,7 @@ public class AlertClientSample {
         AlertClientSample sample = new AlertClientSample();
 
         sample.getAllAlerts();
+        sample.getAllAlertsByState();
         sample.getAlertById();
         sample.updateAlert();
 


### PR DESCRIPTION
<!--- Texts inside this are invisible and will not be displayed on the pull request -->
### Description
<!--- Describe what this change achieves -->
Workaround (enhancement) for costumer issue #17 (actually OV issue).
New method added to `AlertClientSample` to guarantee all alerts will be returned when user wants to get alerts using filters `get(@QueryParam URIQuery query`.

### Issues Resolved
<!--- List any issues this PR will resolve. e.g.: Fixes #01 -->
It does not fix it, but workarounds #17 since this is an OV issue.

---
#### Check List
- ~~[ ] New functionality includes testing~~
- [x] New functionality has been thoroughly documented in the examples
- ~~[ ] New functionality has been documented in the [`README.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/README.md) if applicable~~
- [x] New functionality has been documented in the [`CHANGELOG.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/CHANGELOG.md) if applicable
- ~~[ ] New functionality has been documented in the [`endpoints-support.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/endpoints-support.md) if applicable~~
