### PR TITLE
Fix for Issue#39 authLoginDomain should not be "Local" by default by removing the default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This release adds support to OneView Rest API version 500 to the already existin
 
 
 #### Bug fixes:
+- [#39](https://github.com/HewlettPackard/oneview-sdk-java/issues/39) authLoginDomain should not be "Local" by default
 - [#28](https://github.com/HewlettPackard/oneview-sdk-java/issues/28) `CRM_INCORRECT_VALUE_IN_READONLY_FIELD` returned when updating Logical Switch
 - [#26](https://github.com/HewlettPackard/oneview-sdk-java/issues/26) Exception in `getAllAttachmentPaths` method
 

--- a/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/rest/http/core/client/SDKConfiguration.java
+++ b/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/rest/http/core/client/SDKConfiguration.java
@@ -30,7 +30,7 @@ public class SDKConfiguration {
 
     private static final int DEFAULT_MESSAGE_BUS_PORT = 5671;
     private static final ApiVersion DEFAULT_API_VERSION = ApiVersion.V_300;
-    private static final String DEFAULT_DOMAIN = "LOCAL";
+    //private static final String DEFAULT_DOMAIN = "LOCAL";
 
     private static final String[] MANDATORY_FIELDS = {
             SDKConfiguration.USERNAME,
@@ -121,7 +121,7 @@ public class SDKConfiguration {
     }
 
     public String getOneViewDomain() {
-        return this.properties.getProperty(DOMAIN, DEFAULT_DOMAIN);
+        return this.properties.getProperty(DOMAIN, null);
     }
 
     public static SDKConfiguration fromFile(String filePath) {

--- a/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/rest/http/core/client/SDKConfiguration.java
+++ b/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/rest/http/core/client/SDKConfiguration.java
@@ -30,7 +30,6 @@ public class SDKConfiguration {
 
     private static final int DEFAULT_MESSAGE_BUS_PORT = 5671;
     private static final ApiVersion DEFAULT_API_VERSION = ApiVersion.V_300;
-    // private static final String DEFAULT_DOMAIN = "LOCAL";
 
     private static final String[] MANDATORY_FIELDS = {
             SDKConfiguration.USERNAME,

--- a/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/rest/http/core/client/SDKConfiguration.java
+++ b/oneview-sdk-java-lib/src/main/java/com/hp/ov/sdk/rest/http/core/client/SDKConfiguration.java
@@ -30,7 +30,7 @@ public class SDKConfiguration {
 
     private static final int DEFAULT_MESSAGE_BUS_PORT = 5671;
     private static final ApiVersion DEFAULT_API_VERSION = ApiVersion.V_300;
-    //private static final String DEFAULT_DOMAIN = "LOCAL";
+    // private static final String DEFAULT_DOMAIN = "LOCAL";
 
     private static final String[] MANDATORY_FIELDS = {
             SDKConfiguration.USERNAME,


### PR DESCRIPTION
### Description
It fixes the authLoginDomain should not be "Local" by default.


### Issues Resolved
<!--- List any issues this PR will resolve. e.g.: Fixes #01 -->
[Fixes#39](https://github.com/HewlettPackard/oneview-sdk-java/issues/39)

---
#### Check List
- [X] New functionality includes testing
- [X] New functionality has been thoroughly documented in the examples
- [ ] New functionality has been documented in the [`README.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/README.md) if applicable
- [X] New functionality has been documented in the [`CHANGELOG.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/CHANGELOG.md) if applicable
- [ ] New functionality has been documented in the [`endpoints-support.md`](https://github.com/HewlettPackard/oneview-sdk-java/blob/master/endpoints-support.md) if applicable
